### PR TITLE
Fix issue where failing to resolve repo would crash UI

### DIFF
--- a/src/loki_update/controller.py
+++ b/src/loki_update/controller.py
@@ -698,15 +698,22 @@ class LokiUpdateController():
         for repo in self.available_repos:
             tags = self.get_release_tags_from_repo(repo.get("owner"), repo.get("name"))
             repo_info.append({"name": repo.get("name"), "tags": tags})
-        
+
+        for repo in self.available_repos:
+            try:
+                tags = self.get_release_tags_from_repo(repo.get("owner"), repo.get("name"))
+                repo_info.append({"name": repo.get("name"), "tags": tags})
+            except Exception as e:
+                logging.error('Failed to get information from repo {}; skipping...'.format(repo.get("name")))
+
         return repo_info
-    
+
     def get_release_tags_from_repo(self, owner, repo):
         release_response = requests.get(f"{GITHUB_REPO_API_URL}/{owner}/{repo}/releases")
-        
+
         tags = []
         assets_required = {"image.ub", "BOOT.BIN", "boot.scr"}
-        
+    
         if release_response.status_code != 200:
             raise LokiUpdateError("Unable to fetch releases from repository")
         


### PR DESCRIPTION
If a repo fails to resolve, startup will continue having noted in the log. In addition, other repos will still be scanned for

This PR matches the later one being merged for later versions of odin-react, but there are currently buiild issues with the main branch that need solving. Therefore this PR will merge this important fix beforehand, into a develop branch that will be used to track changes and backports before merging into the main branch when fixed.

The other PR is https://github.com/stfc-aeg/loki-update/pull/15